### PR TITLE
fix: package reference conflict

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -2,4 +2,5 @@
 
 ## 0.4.0
 
-Removed support for Android 10.
+- Removed support for Android 10.
+- Bump Microsoft.Extensions.Logging reference to 5.0.0

--- a/src/Persistence.Abstractions/Persistence.Abstractions.csproj
+++ b/src/Persistence.Abstractions/Persistence.Abstractions.csproj
@@ -20,12 +20,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<!-- Needed for Source Link support -->
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 </Project>

--- a/src/Persistence.Reactive/Persistence.Reactive.csproj
+++ b/src/Persistence.Reactive/Persistence.Reactive.csproj
@@ -24,13 +24,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
 		<PackageReference Include="System.Reactive" Version="4.4.1" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<!-- Needed for Source Link support -->
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Persistence/Persistence.csproj
+++ b/src/Persistence/Persistence.csproj
@@ -20,13 +20,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<!-- Needed for Source Link support -->
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Bug fix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
When compiling on a net6 project, it fails because of dependency conflict with Microsoft.Extensions.Logging.Abstractions.

```
2>{project net6}.csproj : error NU1605: Detected package downgrade: Microsoft.Extensions.Logging.Abstractions from 5.0.0 to 3.1.0. Reference the package directly from the project to select a different version. 
2>{project net6}.csproj : error NU1605:  {project net6}-> Nventive.Persistence 0.4.0-dev.36 -> Uno.Core 4.0.1 -> Microsoft.Extensions.Logging 5.0.0 -> Microsoft.Extensions.Logging.Abstractions (>= 5.0.0) 
2>{project net6}.csproj : error NU1605:  {project net6} -> Nventive.Persistence 0.4.0-dev.36 -> Microsoft.Extensions.Logging.Abstractions (>= 3.1.0)
2>{project net6}.csproj: error NU1605: Detected package downgrade: Microsoft.Extensions.Logging.Abstractions from 5.0.0 to 3.1.0. Reference the package directly from the project to select a different version. 
2>{project net6}.csproj : error NU1605:  {project net6} -> Nventive.Persistence.Reactive 0.4.0-dev.36 -> Nventive.Persistence.Abstractions 0.4.0-dev.36 -> Uno.Core 4.0.1 -> Microsoft.Extensions.Logging 5.0.0 -> Microsoft.Extensions.Logging.Abstractions (>= 5.0.0) 
2>{project net6}.csproj : error NU1605:  {project net6} -> Nventive.Persistence.Reactive 0.4.0-dev.36 -> Microsoft.Extensions.Logging.Abstractions (>= 3.1.0)
```

It's due to the fact that the Uno.Core nuget package reference 5.0.0 for the net6 4.0.1

https://www.nuget.org/packages/Uno.Core/4.0.1#dependencies-body-tab

![image](https://user-images.githubusercontent.com/17461593/222781858-bc83a838-1937-49f5-9cec-90b04c25d53b.png)

## What is the new behavior?
No package conflict when compiling on net6 project

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Documentation has been added/updated~~
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated~~
- [x] **Does** Contains breaking changes
- [ ] ~~Updated the Changelog~~
- [ ] ~~Associated with an issue~~

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

This will forces devs using this package to bump Microsoft.Extensions.Logging packages to at least 5.0.0

## Other information
<!-- Please provide any additional information if necessary -->

