### PR TITLE
feat: add parameter in ctor to set ServiceName for SecRecord

### DIFF
--- a/src/Persistence.Shared/KeychainSettingsStorage.cs
+++ b/src/Persistence.Shared/KeychainSettingsStorage.cs
@@ -22,10 +22,12 @@ namespace Nventive.Persistence
 	{
 		private const string AllKeysAccountName = "Internal_AllKeys_Account";
 		private const string WasKeychainValidatedName = "Keychain_was_validated";
+		private const string DefaultKeychainService = "_KeychainSettingsStorage_";
 
 		private readonly ISettingsSerializer _serializer;
 
 		private readonly FastAsyncLock _clearKeychain = new FastAsyncLock();
+		private readonly string _keychainService;
 
 		/// <summary>
 		/// Creates a new <see cref="KeychainSettingsStorage"/>.
@@ -34,6 +36,18 @@ namespace Nventive.Persistence
 		public KeychainSettingsStorage(ISettingsSerializer serializer)
 		{
 			_serializer = serializer;
+			_keychainService = DefaultKeychainService;
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="KeychainSettingsStorage"/>.
+		/// </summary>
+		/// <param name="serializer">A serializer for transforming values back and forth to strings.</param>
+		/// <param name="keychainService">Keychain service name.</param>
+		public KeychainSettingsStorage(ISettingsSerializer serializer, string keychainService)
+		{
+			_serializer = serializer;
+			_keychainService = keychainService;
 		}
 
 		/// <inheritdoc/>
@@ -245,7 +259,7 @@ namespace Nventive.Persistence
 			{
 				Account = name,
 				Label = name,
-				Service = "_KeychainSettingsStorage_"
+				Service = _keychainService
 			};
 		}
 


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Feature


## What is the current behavior?
There are no ways to change the Service name to use when creating `SecRecord`.


## What is the new behavior?
We can specify a Service name to use on `SecRecord` in `KeyChainSettingsService` constructor.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated~~
- [ ] ~~Contains **NO** breaking changes~~
- [ ] ~~Updated the Changelog~~
- [ ] ~~Associated with an issue~~

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

