### PR TITLE
fix: Use uno-check to compile with .net sdk 7.0.102

### DIFF
--- a/build/stage-build.yml
+++ b/build/stage-build.yml
@@ -1,4 +1,9 @@
-﻿steps:
+﻿parameters:
+  DotNetVersion: '7.0.102'
+  UnoCheck_Version: '1.11.0'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/146b0b4b23d866bef455494a12ad7ffd2f6f2d20/manifests/uno.ui.manifest.json'
+
+steps:
 - task: GitVersion/setup@0
   inputs:
     versionSpec: '5.10.1'
@@ -10,15 +15,21 @@
     configFilePath: $(Build.SourcesDirectory)/build/gitversion.yml
   displayName: 'Calculate version'
 
-- script: dotnet workload install android ios macos maccatalyst"
-  displayName: 'Install .NET workload'
-
-- task: JavaToolInstaller@0
-  displayName: "Install Java SDK 11"
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK ${{ parameters.DotNetVersion }}'
+  retryCountOnTaskFailure: 3
   inputs:
-    versionSpec: '11'
-    jdkArchitectureOption: 'x64'
-    jdkSourceOption: 'PreInstalled'
+    packageType: sdk
+    version: ${{ parameters.DotNetVersion }}
+    includePreviewVersions: true
+
+- powershell: |
+    & dotnet tool update --global uno.check --version ${{ parameters.UnoCheck_Version }} --add-source https://api.nuget.org/v3/index.json
+    & uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip vsmac --skip androidsdk --skip androidemulator --manifest ${{ parameters.UnoCheck_Manifest }}
+  displayName: Install .NET Workloads | Uno-check
+  errorActionPreference: continue
+  ignoreLASTEXITCODE: true
+  retryCountOnTaskFailure: 3
 
 - task: MSBuild@1
   displayName: 'Restore solution packages'


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->
[#294909](https://dev.azure.com/nventive/Practice%20committees/_workitems/edit/294909)

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

 - Bug fix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

Apps which compile using .NET SDK 7 encounter build errors when using Nventive.Persistence

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

Apps which compile using .NET SDK 7.0.102 build correctly

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [X] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [X] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

.NET SDK 7.0.100 has [issues](https://github.com/coverlet-coverage/coverlet/issues/1391( handling dotnet test with coverlet